### PR TITLE
add workaround of post effect light bloom rendering.

### DIFF
--- a/Dev/ace_cpp/core/Graphics/2D/ace.PostEffectRenderer.cpp
+++ b/Dev/ace_cpp/core/Graphics/2D/ace.PostEffectRenderer.cpp
@@ -120,6 +120,10 @@ namespace ace {
 		RenderState state;
 		state.DepthTest = false;
 		state.DepthWrite = false;
+#ifdef __APPLE__
+		// LightBloomで画面が崩れるのを回避。原因は不明。。。
+		state.AlphaBlendState = AlphaBlend::Opacity;
+#endif
 		m_graphics->SetRenderState(state);
 		m_graphics->DrawPolygon(2);
 	}


### PR DESCRIPTION
AlphaBlendを設定しているとLightBloomが崩れるようなのでPostEffectではAlphaBlendをOFFにする回避策を追加。原因は不明。。。
