### PR TITLE
Linux x86_64環境向けのリンクオプションの追加とGCC用のpragmaの追加

### DIFF
--- a/Dev/CMakeLists.txt
+++ b/Dev/CMakeLists.txt
@@ -259,6 +259,11 @@ set_target_properties(asdUnitTestGtest PROPERTIES OUTPUT_NAME_RELEASE "UnitTestG
 set_target_properties(asdUnitTestEngineGtest PROPERTIES OUTPUT_NAME_DEBUG "UnitTestEngineGtest_cpp" )
 set_target_properties(asdUnitTestEngineGtest PROPERTIES OUTPUT_NAME_RELEASE "UnitTestEngineGtest_cpp" )
 
+# Linux x86_64向けの追加のリンクオプション
+if (CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
+	set_target_properties(asdTool PROPERTIES COMPILE_FLAGS "-fPIC")
+endif()
+
 
 # フラグ処理
 if (MSVC)

--- a/Dev/unitTest_cpp_gtest/asd.common.Base_test.cpp
+++ b/Dev/unitTest_cpp_gtest/asd.common.Base_test.cpp
@@ -7,6 +7,9 @@
 #ifdef _WIN32
 #pragma warning( disable: 4309 )
 #endif
+#ifdef __GNUC__
+#pragma GCC diagnostic ignored "-Wnarrowing"
+#endif
 
 using namespace std;
 


### PR DESCRIPTION
ユニットテストのコードにGCC用のコンパイルオプションが抜けていたので追加しました。