### PR TITLE
asd.Window_Imp_*::CallbackOnFocus 関数に null チェックを追加

### DIFF
--- a/Dev/asd_cpp/core/Window/asd.Window_Imp_Win.cpp
+++ b/Dev/asd_cpp/core/Window/asd.Window_Imp_Win.cpp
@@ -15,7 +15,12 @@ void Window_Imp_Win::CallbackOnFocus(GLFWwindow* window, int b)
 	auto w = (Window_Imp_Win*)glfwGetWindowUserPointer(window);
 	if (b == GL_TRUE)
 	{
-		w->OnFocused();
+		auto onFocused = w->OnFocused;
+
+		if (onFocused)
+		{
+			onFocused();
+		}
 	}
 	else
 	{

--- a/Dev/asd_cpp/core/Window/asd.Window_Imp_X11.cpp
+++ b/Dev/asd_cpp/core/Window/asd.Window_Imp_X11.cpp
@@ -15,7 +15,12 @@ void Window_Imp_X11::CallbackOnFocus(GLFWwindow* window, int b)
 	auto w = (Window_Imp_X11*) glfwGetWindowUserPointer(window);
 	if (b == GL_TRUE)
 	{
-		w->OnFocused();
+		auto onFocused = w->OnFocused;
+
+		if (onFocused)
+		{
+			onFocused();
+		}
 	}
 	else
 	{


### PR DESCRIPTION
一部 Windows 環境で起動できない問題を解決するもの。
要動作検証