### PR TITLE
[asd-cpp] various fixes for Linux and C++11

### DIFF
--- a/Dev/CMakeLists.txt
+++ b/Dev/CMakeLists.txt
@@ -20,7 +20,7 @@ endif()
 if (MSVC)
 	# “Á‚É‰½‚à
 else()
-	set(CMAKE_CXX_FLAGS "-std=c++11 -fPIC" ${CMAKE_CXX_FLAGS})
+	set(CMAKE_CXX_FLAGS "-std=c++11 -fPIC -fpermissive" ${CMAKE_CXX_FLAGS})
 	set(CMAKE_C_FLAGS "-fPIC" ${CMAKE_C_FLAGS})
 
 endif()

--- a/Dev/asd_cpp/common/Utility/asd.BinaryReader.h
+++ b/Dev/asd_cpp/common/Utility/asd.BinaryReader.h
@@ -2,6 +2,7 @@
 #include<vector>
 #include<fstream>
 #include<string>
+#include<cstring>
 #include<cstdlib>
 #include<algorithm>
 #include<cstdint>

--- a/Dev/asd_cpp/core/Graphics/3D/Object/asd.RenderedEffectObject3D.h
+++ b/Dev/asd_cpp/core/Graphics/3D/Object/asd.RenderedEffectObject3D.h
@@ -29,7 +29,7 @@ namespace asd
 #elif __APPLE__
 		bool							m_syncEffects = nullptr;
 #else
-        bool							m_syncEffects = false;
+		bool							m_syncEffects = false;
 #endif
 
 		RenderedEffectObject3DProxy*				proxy = nullptr;

--- a/Dev/asd_cpp/core/Graphics/3D/Object/asd.RenderedEffectObject3D.h
+++ b/Dev/asd_cpp/core/Graphics/3D/Object/asd.RenderedEffectObject3D.h
@@ -24,7 +24,13 @@ namespace asd
 		std::vector<Effekseer::Handle>	m_handles;
 		Effect*							m_effect;
 		Renderer3D*						m_renderer = nullptr;
+#if _WIN32
 		bool							m_syncEffects = nullptr;
+#elif __APPLE__
+		bool							m_syncEffects = nullptr;
+#else
+        bool							m_syncEffects = false;
+#endif
 
 		RenderedEffectObject3DProxy*				proxy = nullptr;
 

--- a/Dev/asd_cpp/core/Graphics/Platform/GL/asd.Graphics_Imp_GL.cpp
+++ b/Dev/asd_cpp/core/Graphics/Platform/GL/asd.Graphics_Imp_GL.cpp
@@ -900,7 +900,7 @@ End:;
 #if _WIN32
 #elif __APPLE__
 #else
-Graphics_Imp_GL* Graphics_Imp_GL::Create_X11(void* display, void* window, int32_t width, int32_t height, Log* log, File* file, bool isReloadingEnabled, bool isFullScreen )
+Graphics_Imp_GL* Graphics_Imp_GL::Create_X11(void* display, void* window, int32_t width, int32_t height, Log* log, File* file, GraphicsOption option)
 {
 	auto writeLogHeading = [log](const astring s) -> void
 	{
@@ -949,7 +949,7 @@ Graphics_Imp_GL* Graphics_Imp_GL::Create_X11(void* display, void* window, int32_
 	writeLog(ToAString("OpenGL初期化成功"));
 	writeLog(ToAString(""));
 
-	return new Graphics_Imp_GL( asd::Vector2DI(width,height), display, window, context_, log, file, isReloadingEnabled, isFullScreen);
+	return new Graphics_Imp_GL( asd::Vector2DI(width,height), display, window, context, log, file, option);
 
 End:;
 	writeLog(ToAString("OpenGL初期化失敗"));

--- a/Dev/asd_cpp/core/Graphics/Platform/GL/asd.Graphics_Imp_GL.h
+++ b/Dev/asd_cpp/core/Graphics/Platform/GL/asd.Graphics_Imp_GL.h
@@ -120,7 +120,7 @@ namespace asd {
 #if _WIN32
 #elif __APPLE__
 #else
-		static Graphics_Imp_GL* Create_X11(void* display, void* window, int32_t width, int32_t height, Log* log, File* file, bool isReloadingEnabled, bool isFullScreen);
+		static Graphics_Imp_GL* Create_X11(void* display, void* window, int32_t width, int32_t height, Log* log, File* file, GraphicsOption option);
 #endif
 
 		Texture2D_Imp* CreateTexture2D_Imp_Internal(Graphics* graphics, uint8_t* data, int32_t size) override;

--- a/Dev/asd_cpp/core/Graphics/Resource/asd.ImagePackage_Imp.cpp
+++ b/Dev/asd_cpp/core/Graphics/Resource/asd.ImagePackage_Imp.cpp
@@ -119,7 +119,20 @@ namespace asd
 
 	ImagePackageAdditionalElementType ImagePackage_Imp::GetAdditionalElementType(int32_t index)
 	{
+
+#if _WIN32
 		if (index < 0 || textures.size() <= index) return ImagePackageAdditionalElementType::None;
+
+#elif __APPLE__
+        if (index < 0 || textures.size() <= index) return ImagePackageAdditionalElementType::None;
+
+#else
+
+#undef None
+		if (index < 0 || textures.size() <= index) return ImagePackageAdditionalElementType::None;
+#define None 0L
+
+#endif
 		return additionalElementTypes[index];
 	}
 }

--- a/Dev/asd_cpp/core/Graphics/Resource/asd.ImagePackage_Imp.cpp
+++ b/Dev/asd_cpp/core/Graphics/Resource/asd.ImagePackage_Imp.cpp
@@ -124,7 +124,7 @@ namespace asd
 		if (index < 0 || textures.size() <= index) return ImagePackageAdditionalElementType::None;
 
 #elif __APPLE__
-        if (index < 0 || textures.size() <= index) return ImagePackageAdditionalElementType::None;
+		if (index < 0 || textures.size() <= index) return ImagePackageAdditionalElementType::None;
 
 #else
 

--- a/Dev/asd_cpp/core/ObjectSystem/2D/asd.CoreEffectObject2D_Imp.h
+++ b/Dev/asd_cpp/core/ObjectSystem/2D/asd.CoreEffectObject2D_Imp.h
@@ -14,7 +14,13 @@ namespace asd
 
 		std::vector<Effekseer::Handle>	m_handles;
 		Effect*							m_effect;
+#if _WIN32
 		bool							m_syncEffects = nullptr;
+#elif __APPLE__
+		bool							m_syncEffects = nullptr;
+#else
+        bool							m_syncEffects = false;
+#endif
 		Renderer2D_Imp*					m_renderer;
 		int								m_drawingPtiority;
 

--- a/Dev/asd_cpp/core/ObjectSystem/2D/asd.CoreEffectObject2D_Imp.h
+++ b/Dev/asd_cpp/core/ObjectSystem/2D/asd.CoreEffectObject2D_Imp.h
@@ -19,7 +19,7 @@ namespace asd
 #elif __APPLE__
 		bool							m_syncEffects = nullptr;
 #else
-        bool							m_syncEffects = false;
+		bool							m_syncEffects = false;
 #endif
 		Renderer2D_Imp*					m_renderer;
 		int								m_drawingPtiority;

--- a/Dev/unitTest_cpp_gtest/Utility/asd.ToU16StringTest.cpp
+++ b/Dev/unitTest_cpp_gtest/Utility/asd.ToU16StringTest.cpp
@@ -3,10 +3,25 @@
 #include<string>
 
 TEST(Utility, ToU16StringTest) {
-	using namespace std::string_literals;
-	ASSERT_EQ(asd::ToU16String(42), u"42"s);
+#if _WIN32
+    using namespace std::string_literals;
+    ASSERT_EQ(asd::ToU16String(42), u"42"s);
 	ASSERT_EQ(asd::ToU16String(31337L), u"31337"s);
 	ASSERT_EQ(asd::ToU16String(3.14).substr(0, 4), u"3.14"s); // compare only first 4 chars because we don't know the number of zeros trailing
 	ASSERT_EQ(asd::ToU16String(3.14f).substr(0, 4), u"3.14"s);
 
-}
+#elif __APPLE__
+    using namespace std::string_literals;
+    ASSERT_EQ(asd::ToU16String(42), u"42"s);
+	ASSERT_EQ(asd::ToU16String(31337L), u"31337"s);
+	ASSERT_EQ(asd::ToU16String(3.14).substr(0, 4), u"3.14"s); // compare only first 4 chars because we don't know the number of zeros trailing
+	ASSERT_EQ(asd::ToU16String(3.14f).substr(0, 4), u"3.14"s);
+
+#else
+    ASSERT_EQ(asd::ToU16String(42), u"42");
+	ASSERT_EQ(asd::ToU16String(31337L), u"31337");
+	ASSERT_EQ(asd::ToU16String(3.14).substr(0, 4), u"3.14"); // compare only first 4 chars because we don't know the number of zeros trailing
+	ASSERT_EQ(asd::ToU16String(3.14f).substr(0, 4), u"3.14");
+
+#endif
+   }

--- a/Dev/unitTest_cpp_gtest/Utility/asd.ToU16StringTest.cpp
+++ b/Dev/unitTest_cpp_gtest/Utility/asd.ToU16StringTest.cpp
@@ -4,21 +4,21 @@
 
 TEST(Utility, ToU16StringTest) {
 #if _WIN32
-    using namespace std::string_literals;
-    ASSERT_EQ(asd::ToU16String(42), u"42"s);
+	using namespace std::string_literals;
+	ASSERT_EQ(asd::ToU16String(42), u"42"s);
 	ASSERT_EQ(asd::ToU16String(31337L), u"31337"s);
 	ASSERT_EQ(asd::ToU16String(3.14).substr(0, 4), u"3.14"s); // compare only first 4 chars because we don't know the number of zeros trailing
 	ASSERT_EQ(asd::ToU16String(3.14f).substr(0, 4), u"3.14"s);
 
 #elif __APPLE__
-    using namespace std::string_literals;
-    ASSERT_EQ(asd::ToU16String(42), u"42"s);
+	using namespace std::string_literals;
+	ASSERT_EQ(asd::ToU16String(42), u"42"s);
 	ASSERT_EQ(asd::ToU16String(31337L), u"31337"s);
 	ASSERT_EQ(asd::ToU16String(3.14).substr(0, 4), u"3.14"s); // compare only first 4 chars because we don't know the number of zeros trailing
 	ASSERT_EQ(asd::ToU16String(3.14f).substr(0, 4), u"3.14"s);
 
 #else
-    ASSERT_EQ(asd::ToU16String(42), u"42");
+	ASSERT_EQ(asd::ToU16String(42), u"42");
 	ASSERT_EQ(asd::ToU16String(31337L), u"31337");
 	ASSERT_EQ(asd::ToU16String(3.14).substr(0, 4), u"3.14"); // compare only first 4 chars because we don't know the number of zeros trailing
 	ASSERT_EQ(asd::ToU16String(3.14f).substr(0, 4), u"3.14");


### PR DESCRIPTION
It is expected that some of those issues (especially related to C++11) also happen on OS X.

Please remove the ```#elif __APPLE__``` part to apply these fixes to OS X build too.